### PR TITLE
Configure container to use maila apt packages.

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -2,19 +2,27 @@
 set -e
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+# https://stackoverflow.com/questions/28279862/docker-and-bash-history
+export HISTFILE=~/.persistent-volume/.bash_history
+echo "export HISTFILE=${HISTFILE}" >> /home/ros/.bashrc
+touch $HISTFILE
 
-echo "Downloading maila-rosdep from maila_packages and making them available to rosdep. "
-sudo sh -c 'mkdir -p /usr/share/rosdep'
-sudo sh -c 'curl https://raw.githubusercontent.com/Mailamaca/maila_packages/main/maila-rosdep.yaml > /usr/share/rosdep/maila-rosdep.yaml'
-sudo sh -c 'echo yaml file:////usr/share/rosdep/maila-rosdep.yaml >> /etc/ros/rosdep/sources.list.d/10-maila.list'
-
-echo "Adding sources for Maila packages..."
-# see https://github.com/Mailamaca/maila_packages/blob/jammy-humble/README.md
+# Set Maila apt sources.
 echo "deb [trusted=yes] https://raw.githubusercontent.com/Mailamaca/maila_packages/jammy-humble/ ./" | sudo tee /etc/apt/sources.list.d/Mailamaca_maila_packages.list
 echo "yaml https://raw.githubusercontent.com/Mailamaca/maila_packages/jammy-humble/local.yaml humble" | sudo tee /etc/ros/rosdep/sources.list.d/1-Mailamaca_maila_packages.list
-echo "...finished."
 
-echo "Installing rosdep."
+# maila local packages
+echo "yaml https://raw.githubusercontent.com/Mailamaca/maila_packages/jammy-humble/local.yaml" | sudo tee /etc/ros/rosdep/sources.list.d/10-maila.list
+# maila external packages
+echo "yaml https://raw.githubusercontent.com/Mailamaca/maila_packages/main/maila-rosdep.yaml" | sudo tee /etc/ros/rosdep/sources.list.d/10-maila.list
+
+pushd "${SCRIPT_DIR}/../rosdep"
+echo "echo yaml file:///${PWD}/maila-rosdep.yaml >> /etc/ros/rosdep/sources.list.d/10-maila.list"
+sudo sh -c 'echo yaml file:///${PWD}/maila-rosdep.yaml >> /etc/ros/rosdep/sources.list.d/10-maila.list'
+popd
+
+
+echo "Installing rosdep..."
 sudo apt update
 rosdep update
 rosdep install --from-paths $SCRIPT_DIR/../src --ignore-src -y

--- a/rosdep/maila-rosdep.yaml
+++ b/rosdep/maila-rosdep.yaml
@@ -1,6 +1,0 @@
-libltdl:
-  ubuntu:
-    jammy: [libltdl-dev]
-libpng:
-  ubuntu:
-    jammy: [libpng-dev]


### PR DESCRIPTION
After this commit the Maila packages that are
built from the github action of https://github.com/Mailamaca/maila_packages are available to install inside the container.
Also the rosdep will be correctly resolved to the corresponding maila package.

Closes: MAILA-51


For example for installing the vesc_driver would be enough to run `apt install vesc_driver` ... therefore no more need to clone and compile the src code when we do not want to develop new feature on the packages :) 